### PR TITLE
making properties getters to only run require when called

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,17 @@
 
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
+var lazy = require('lazy-cache')(require);
+var lazyPath = lazy('path');
+var lazyFs = lazy('fs');
 
 module.exports = function exportFiles(dir) {
   if (typeof dir !== 'string') {
     throw new TypeError('export-files expects `dir` to be a string.');
   }
+
+  var path = lazyPath();
+  var fs = lazyFs();
 
   var dirs = tryReaddir(dir);
   var len = dirs.length;
@@ -23,7 +27,7 @@ module.exports = function exportFiles(dir) {
     var name = dirs[len];
     var fp = path.resolve(dir, name);
     if (!fs.statSync(fp).isDirectory() && isValid(fp)) {
-      defineProp(res, basename(name), fp);
+      defineProp(res, basename(name), lazy(fp));
     }
   }
   return res;
@@ -39,6 +43,7 @@ function basename(fp) {
 }
 
 function tryReaddir(fp) {
+  var fs = lazyFs();
   try {
     return fs.readdirSync(fp);
   } catch(err) {
@@ -48,12 +53,12 @@ function tryReaddir(fp) {
   }
 }
 
-function defineProp (obj, name, fp) {
+function defineProp (obj, name, lazyMod) {
   Object.defineProperty(obj, name, {
     enumerable: true,
     configurable: true,
     get: function () {
-      return require(fp);
+      return lazyMod();
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function exportFiles(dir) {
     var name = dirs[len];
     var fp = path.resolve(dir, name);
     if (!fs.statSync(fp).isDirectory() && isValid(fp)) {
-      res[basename(name)] = require(fp);
+      defineProp(res, basename(name), fp);
     }
   }
   return res;
@@ -48,12 +48,12 @@ function tryReaddir(fp) {
   }
 }
 
-function tryRequire(fp) {
-  try {
-    return require(fp);
-  } catch(err) {
-    err.origin = __dirname;
-    err.msg = 'export-dirs cannot require: ' + fp;
-    throw new Error(err);
-  }
+function defineProp (obj, name, fp) {
+  Object.defineProperty(obj, name, {
+    enumerable: true,
+    configurable: true,
+    get: function () {
+      return require(fp);
+    }
+  });
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "files",
     "module",
     "modules"
-  ]
+  ],
+  "dependencies": {
+    "lazy-cache": "^0.1.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -11,20 +11,6 @@ var path = require('path');
 require('should');
 var exportFiles = require('./');
 
-/**
- * Support functions
- */
-
-function rename(fp) {
-  return path.basename(fp);
-}
-
-function filter(re) {
-  return function(fp) {
-    return re.test(fp);
-  }
-}
-
 // path must be absolute for requires to work
 var fixtures = path.join(process.cwd(), 'fixtures');
 


### PR DESCRIPTION
Did some clean up and setup property getters to make require calls only when needed. Doing a PR in case you don't think this is a good idea.
